### PR TITLE
Added a slash to the end of the path line 65

### DIFF
--- a/installation/binary-guide.md
+++ b/installation/binary-guide.md
@@ -62,7 +62,7 @@ If you'd rather start the application as a service, use the following commands:
 ```
 sudo addgroup cortex
 sudo adduser --system cortex
-sudo cp /opt/cortex/package/cortex.service /usr/lib/systemd/system
+sudo cp /opt/cortex/package/cortex.service /usr/lib/systemd/system/
 sudo chown -R cortex:cortex /opt/cortex
 sudo chgrp cortex /etc/cortex/application.conf
 sudo chmod 640 /etc/cortex/application.conf


### PR DESCRIPTION
The slash is need to stop the user from overwriting the /usr/lib/systemd/system directory with the contents of cortex.service